### PR TITLE
Update txtai.json

### DIFF
--- a/docs/tools/vdb_table/data/txtai.json
+++ b/docs/tools/vdb_table/data/txtai.json
@@ -2,7 +2,7 @@
   "name": "txtai",
   "links": {
     "docs": "https://neuml.github.io/txtai/",
-    "github": "https://neuml.github.io/txtai/",
+    "github": "https://github.com/neuml/txtai",
     "website": "https://neuml.github.io/txtai/",
     "vendor_discussion": "https://github.com/superlinked/VectorHub/discussions/86",
     "poc_github": "https://github.com/davidmezzetti",
@@ -25,7 +25,7 @@
     "source_url": "",
     "comment": ""
   },
-  "github_stars": 5500,
+  "github_stars": 5972,
   "vector_launch_year": 2020,
   "metadata_filter": {
     "support": "full",
@@ -113,9 +113,9 @@
     "comment": ""
   },
   "in_process": {
-    "support": "none",
+    "support": "full",
     "source_url": "",
-    "comment": ""
+    "comment": "txtai embeddings indexes can be loaded and run directly in a Python application"
   },
   "multi_tenancy": {
     "support": "",
@@ -123,9 +123,9 @@
     "comment": ""
   },
   "disk_index": {
-    "support": "",
+    "support": "full",
     "source_url": "",
-    "comment": ""
+    "comment": "txtai embeddings indexes can be saved to a directory, tar.gz file and/or to object storage such as S3"
   },
   "ephemeral": {
     "support": "full",


### PR DESCRIPTION
Very nice looking website, thank you for putting this all together.

This PR suggests the following changes:

- GitHub repo should be https://github.com/neuml/txtai
- In-process is supported. txtai embeddings instances can be loaded directly in a Python application. Probably one of the more common use cases.
- Disk Indexes are supported. txtai indexes can be saved to a directory, tar.gz file and/or to object storage such as S3.

Additionally, I wasn't exactly sure on the following fields, clarification would be helpful to decide if this is/isn't a supported feature.
 
- Embeddings structured: An associated graph can be built alongside txtai embeddings, not sure if that was the meaning here?
- Sparse vs BM25: txtai can build TF-IDF indexes in addition to BM25. But those indexes are primarily there for hybrid search, is this something different?
 
Thanks again for including txtai in the discussion!