### PR TITLE
Update MyScale license

### DIFF
--- a/docs/tools/vdb_table/data/myscale.json
+++ b/docs/tools/vdb_table/data/myscale.json
@@ -2,7 +2,7 @@
   "name": "MyScale",
   "links": {
     "docs": "https://myscale.com/docs/en/vector-search/",
-    "github": "https://github.com/myscale",
+    "github": "https://github.com/myscale/myscaledb",
     "website": "https://myscale.com/",
     "vendor_discussion": "https://github.com/superlinked/VectorHub/discussions/101",
     "poc_github": "https://github.com/lqhl",
@@ -149,8 +149,8 @@
     "comment": ""
   },
   "github_stars": {
-    "value": 0,
-    "source_url": "",
+    "value": 55,
+    "source_url": "https://github.com/myscale/myscaledb",
     "comment": "",
     "value_90_days": 0
   },

--- a/docs/tools/vdb_table/data/myscale.json
+++ b/docs/tools/vdb_table/data/myscale.json
@@ -9,12 +9,12 @@
     "slug": "myscale"
   },
   "oss": {
-    "support": "none",
+    "support": "full",
     "source_url": "",
-    "comment": ""
+    "comment": "Publicly announced on X on 29 Mar 2024: https://twitter.com/MyScaleDB/status/1773720536297992359"
   },
   "license": {
-    "value": "Proprietary",
+    "value": "Apache-2.0",
     "source_url": "",
     "comment": ""
   },


### PR DESCRIPTION
MyScale announced that they're going open source with an Apache 2.0 licence:
https://twitter.com/MyScaleDB/status/1773720536297992359

This PR makes the update.