### PR TITLE
Updating Redisearch info, numbers and links

### DIFF
--- a/docs/tools/vdb_table/data/redis.json
+++ b/docs/tools/vdb_table/data/redis.json
@@ -2,10 +2,10 @@
   "name": "Redis Search",
   "links": {
     "docs": "https://redis.io/docs/get-started/vector-database/",
-    "github": "https://github.com/RedisAI/VectorSimilarity",
+    "github": "https://github.com/RediSearch/RediSearch",
     "website": "https://redis.com/solutions/use-cases/vector-database/",
     "vendor_discussion": "https://github.com/superlinked/VectorHub/discussions/81",
-    "poc_github": "https://github.com/tylerhutcherson",
+    "poc_github": "https://github.com/adrianoamaral",
     "slug": "redis"
   },
   "oss": {
@@ -127,8 +127,8 @@
     "comment": ""
   },
   "ephemeral": {
-    "support": "",
-    "source_url": "",
+    "support": "full",
+    "source_url": "https://redis.io/blog/the-case-for-ephemeral-search/",
     "comment": ""
   },
   "sharding": {
@@ -149,15 +149,15 @@
     "comment": ""
   },
   "github_stars": {
-    "value": 34,
-    "source_url": "https://github.com/RedisAI/VectorSimilarity",
+    "value": 5200,
+    "source_url": "https://github.com/RediSearch/RediSearch",
     "comment": "",
     "value_90_days": 0
   },
   "docker_pulls": {
-    "value": 0,
-    "source_url": "",
-    "comment": "",
+    "value": 5000000,
+    "source_url": "https://hub.docker.com/r/redis/redis-stack",
+    "comment": "Vector Search is part of the Redis Stack",
     "value_90_days": 0
   },
   "pypi_downloads": {

--- a/docs/tools/vdb_table/data/redis.json
+++ b/docs/tools/vdb_table/data/redis.json
@@ -151,7 +151,7 @@
   "github_stars": {
     "value": 5200,
     "source_url": "https://github.com/RediSearch/RediSearch",
-    "comment": "",
+    "comment": "Vector Search library is part of RediSearch https://github.com/RediSearch/RediSearch/tree/master/deps",
     "value_90_days": 0
   },
   "docker_pulls": {


### PR DESCRIPTION
This PRs update few Redis information Vectors search support:

- link and references to Redisearch GH repo
- change the POC
- fix the GitHub stars numbers
- add the docker pull numbers
- add the support to the ephemeral index feature