### PR TITLE
Vespa has multinode support using bucket distribution

### DIFF
--- a/docs/tools/vdb_table/data/vespa.json
+++ b/docs/tools/vdb_table/data/vespa.json
@@ -133,9 +133,9 @@
     "comment": ""
   },
   "sharding": {
-    "support": "",
-    "source_url": "",
-    "comment": ""
+    "support": "full",
+    "source_url": "https://docs.vespa.ai/en/elasticity.html",
+    "comment": "Vespa distributes documents over nodes using buckets, see https://docs.vespa.ai/en/content/buckets.html"
   },
   "doc_size": {
     "bytes": 0,


### PR DESCRIPTION
Ref discussion on LinkedIn:

Vespa distributes the index over multiple machines, ref https://docs.vespa.ai/en/elasticity.html - but in a more sophisticated way than shards as found in other platforms. So maybe "distributed index" is a better name. If you keep "Sharding", it is more correct to put a green check on Vespa than not, as Vespa supports index distribution.