### PR TITLE
Update docker url for Weaviate

### DIFF
--- a/docs/tools/vdb_table/data/weaviate.json
+++ b/docs/tools/vdb_table/data/weaviate.json
@@ -171,8 +171,8 @@
     "value_90_days": 0
   },
   "docker_pulls": {
-    "value": 0,
-    "source_url": "",
+    "value": 4639680,
+    "source_url": "https://hub.docker.com/r/semitechnologies/weaviate",
     "comment": "",
     "value_90_days": 0
   },


### PR DESCRIPTION
Hi team,

I've added the docker source_url for Weaviate.
Note: the namespace is `semitechnologies`, as that was the name of the company when we registered the first Weaviate docker image.