### PR TITLE
revert incorrect bm25 claim by qdrant

### DIFF
--- a/docs/tools/vdb_table/data/qdrant.json
+++ b/docs/tools/vdb_table/data/qdrant.json
@@ -59,7 +59,7 @@
   "bm25": {
     "support": "none",
     "source_url": "https://qdrant.tech/articles/sparse-vectors",
-    "comment": "https://qdrant.tech/articles/sparse-vectors"
+    "comment": ""
   },
   "full_text": {
     "support": "full",

--- a/docs/tools/vdb_table/data/qdrant.json
+++ b/docs/tools/vdb_table/data/qdrant.json
@@ -54,17 +54,17 @@
   "sparse_vectors": {
     "support": "full",
     "source_url": "https://qdrant.tech/articles/sparse-vectors",
-    "comment": "https://qdrant.tech/articles/sparse-vectors"
+    "comment": ""
   },
   "bm25": {
-    "support": "full",
+    "support": "none",
     "source_url": "https://qdrant.tech/articles/sparse-vectors",
     "comment": "https://qdrant.tech/articles/sparse-vectors"
   },
   "full_text": {
     "support": "full",
-    "source_url": "https://qdrant.tech/documentation/concepts/indexing/",
-    "comment": "https://qdrant.tech/documentation/concepts/indexing/#full-text-index"
+    "source_url": "https://qdrant.tech/documentation/concepts/indexing/#full-text-index",
+    "comment": ""
   },
   "embeddings_text": {
     "support": "full",


### PR DESCRIPTION
---
labels: 'vdb comparison'
---

## Describe your changes

## Link to relevant [discussion](https://github.com/superlinked/VectorHub/discussions/categories/vdb-comparison)

## Checklist before requesting a review
- [x] I have followed the [contribution guidelines](https://github.com/superlinked/VectorHub/tree/main/docs/tools/vdb_table)
- [x] I have provided a reference for each attribute for which I'm adding a "support" claim.
