### PR TITLE
Add Chromia Vector DB

### DIFF
--- a/docs/tools/vdb_table/data/chromia.json
+++ b/docs/tools/vdb_table/data/chromia.json
@@ -143,10 +143,10 @@
       "comment": ""
     },
     "vector_dims": {
-      "value": 1536,
+      "value": 2000,
       "unlimited": false,
-      "source_url": "",
-      "comment": "For now, the soft limit is 1536 but there is no official documentation about this. It depends on the embedding model as well"
+      "source_url": "https://github.com/pgvector/pgvector",
+      "comment": ""
     },
     "index_types": {
       "value": [

--- a/docs/tools/vdb_table/data/chromia.json
+++ b/docs/tools/vdb_table/data/chromia.json
@@ -143,9 +143,9 @@
       "comment": ""
     },
     "vector_dims": {
-      "value": 2000,
+      "value": 0,
       "unlimited": false,
-      "source_url": "https://github.com/pgvector/pgvector",
+      "source_url": "",
       "comment": ""
     },
     "index_types": {

--- a/docs/tools/vdb_table/data/chromia.json
+++ b/docs/tools/vdb_table/data/chromia.json
@@ -1,0 +1,188 @@
+{
+    "name": "Chroma",
+    "links": {
+      "docs": "https://docs.chromia.com/intro/extensions/vector-db",
+      "github": "https://gitlab.com/chromaway/core/vector-db-extension",
+      "website": "https://chromia.com/",
+      "vendor_discussion": "https://github.com/superlinked/VectorHub/discussions/544",
+      "poc_github": "https://gitlab.com/johan.nilssonn",
+      "slug": "chromia"
+    },
+    "oss": {
+      "support": "full",
+      "source_url": "",
+      "comment": ""
+    },
+    "license": {
+      "value": "GPL-3.0",
+      "source_url": "https://www.gnu.org/licenses/",
+      "comment": ""
+    },
+    "dev_languages": {
+      "value": [
+        "kotlin"
+      ],
+      "source_url": "",
+      "comment": ""
+    },
+    "vector_launch_year": 2025,
+    "metadata_filter": {
+      "support": "partial",
+      "source_url": "",
+      "comment": ""
+    },
+    "hybrid_search": {
+      "support": "partial",
+      "source_url": "",
+      "comment": ""
+    },
+    "facets": {
+      "support": "",
+      "source_url": "",
+      "comment": ""
+    },
+    "geo_search": {
+      "support": "",
+      "source_url": "",
+      "comment": ""
+    },
+    "multi_vec": {
+      "support": "none",
+      "source_url": "",
+      "comment": ""
+    },
+    "sparse_vectors": {
+      "support": "none",
+      "source_url": "",
+      "comment": ""
+    },
+    "bm25": {
+      "support": "none",
+      "source_url": "",
+      "comment": ""
+    },
+    "full_text": {
+      "support": "partial",
+      "source_url": "https://docs.trychroma.com/guides#filtering-by-document-contents",
+      "comment": ""
+    },
+    "embeddings_text": {
+      "support": "none",
+      "source_url": "",
+      "comment": ""
+    },
+    "embeddings_image": {
+      "support": "none",
+      "source_url": "",
+      "comment": ""
+    },
+    "embeddings_structured": {
+      "support": "",
+      "source_url": "",
+      "comment": ""
+    },
+    "rag": {
+      "support": "",
+      "source_url": "",
+      "comment": ""
+    },
+    "recsys": {
+      "support": "",
+      "source_url": "",
+      "comment": ""
+    },
+    "langchain": {
+      "support": "",
+      "source_url": "",
+      "comment": ""
+    },
+    "llamaindex": {
+      "support": "",
+      "source_url": "",
+      "comment": ""
+    },
+    "managed_cloud": {
+      "support": "full",
+      "source_url": "https://chromia.com/mainnet",
+      "comment": ""
+    },
+    "pricing": {
+      "value": "",
+      "source_url": "",
+      "comment": ""
+    },
+    "in_process": {
+      "support": "",
+      "source_url": "",
+      "comment": ""
+    },
+    "multi_tenancy": {
+      "support": "",
+      "source_url": "",
+      "comment": ""
+    },
+    "disk_index": {
+      "support": "",
+      "source_url": "",
+      "comment": ""
+    },
+    "ephemeral": {
+      "support": "none",
+      "source_url": "",
+      "comment": ""
+    },
+    "sharding": {
+      "support": "full",
+      "source_url": "",
+      "comment": ""
+    },
+    "doc_size": {
+      "bytes": 0,
+      "unlimited": false,
+      "source_url": "",
+      "comment": ""
+    },
+    "vector_dims": {
+      "value": 2000,
+      "unlimited": false,
+      "source_url": "",
+      "comment": ""
+    },
+    "index_types": {
+      "value": [
+        "HNSW"
+      ],
+      "source_url": "",
+      "comment": ""
+    },
+    "github_stars": {
+      "value": 0,
+      "source_url": "",
+      "comment": "",
+      "value_90_days": 0
+    },
+    "docker_pulls": {
+      "value": 0,
+      "source_url": "",
+      "comment": "",
+      "value_90_days": 0
+    },
+    "pypi_downloads": {
+      "value": 0,
+      "source_url": "",
+      "comment": "",
+      "value_90_days": 0
+    },
+    "npm_downloads": {
+      "value": 0,
+      "source_url": "",
+      "comment": "",
+      "value_90_days": 0
+    },
+    "crates_io_downloads": {
+      "value": 0,
+      "source_url": "",
+      "comment": "",
+      "value_90_days": 0
+    }
+  }

--- a/docs/tools/vdb_table/data/chromia.json
+++ b/docs/tools/vdb_table/data/chromia.json
@@ -10,7 +10,7 @@
     },
     "oss": {
       "support": "full",
-      "source_url": "",
+      "source_url": "https://gitlab.com/chromaway/core/vector-db-extension/-/blob/dev/LICENSE",
       "comment": ""
     },
     "license": {
@@ -27,7 +27,7 @@
     },
     "vector_launch_year": 2025,
     "metadata_filter": {
-      "support": "partial",
+      "support": "",
       "source_url": "",
       "comment": ""
     },
@@ -63,7 +63,7 @@
     },
     "full_text": {
       "support": "partial",
-      "source_url": "https://docs.trychroma.com/guides#filtering-by-document-contents",
+      "source_url": "https://gitlab.com/chromaway/core/vector-db-extension#local-run-and-example",
       "comment": ""
     },
     "embeddings_text": {
@@ -143,10 +143,10 @@
       "comment": ""
     },
     "vector_dims": {
-      "value": 2000,
+      "value": 1536,
       "unlimited": false,
       "source_url": "",
-      "comment": ""
+      "comment": "For now, the soft limit is 1536 but there is no official documentation about this. It depends on the embedding model as well"
     },
     "index_types": {
       "value": [

--- a/docs/tools/vdb_table/data/chromia.json
+++ b/docs/tools/vdb_table/data/chromia.json
@@ -33,7 +33,7 @@
     },
     "hybrid_search": {
       "support": "partial",
-      "source_url": "",
+      "source_url": "https://docs.chromia.com/intro/extensions/vector-db#querying-vectors",
       "comment": ""
     },
     "facets": {
@@ -143,10 +143,10 @@
       "comment": ""
     },
     "vector_dims": {
-      "value": 0,
+      "value": 2000,
       "unlimited": false,
-      "source_url": "",
-      "comment": ""
+      "source_url": "https://github.com/pgvector/pgvector",
+      "comment": "Powered by pgvector - open-source vector similarity"
     },
     "index_types": {
       "value": [

--- a/docs/tools/vdb_table/data/chromia.json
+++ b/docs/tools/vdb_table/data/chromia.json
@@ -1,5 +1,5 @@
 {
-    "name": "Chroma",
+    "name": "Chromia",
     "links": {
       "docs": "https://docs.chromia.com/intro/extensions/vector-db",
       "github": "https://gitlab.com/chromaway/core/vector-db-extension",


### PR DESCRIPTION
This pull request adds [Chromia's Vector DB](https://docs.chromia.com/intro/extensions/vector-db) to the vector database comparison table