### PR TITLE
ci: replace DATA_PUSH_TOKEN PAT with sie-web-sync-bot app token

### DIFF
--- a/.github/workflows/data-fetch-push.yml
+++ b/.github/workflows/data-fetch-push.yml
@@ -1,52 +1,60 @@
 name: Update Stars, Pulls and Downloads From APIs
 
+# Authenticates via the sie-web-sync-bot GitHub App (the same app used by
+# notify-sie-web-vdb.yml). App installation tokens are minted per-run with
+# a 1h lifetime, so there is no PAT expiry to manage.
+
 on:
   schedule:
     - cron: '0 8 * * 1' # Runs at 8:00 AM every Monday
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   fetchAndUpdate:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        python-version: [3.10.13]
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.head_ref }}
-        token: ${{ secrets.DATA_PUSH_TOKEN }}
+      - name: Mint sie-web-sync-bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: superlinked
+          repositories: VectorHub
+          permission-contents: write
+          permission-metadata: read
 
-    - name: Add dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install requests
-        pip install tqdm
-        pip install pypistats
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
-    - name: Set pepy.tech API key
-      run: |
-        echo "PYPI_API_KEY=${{ secrets.PYPI_API_KEY }}" >> $GITHUB_ENV
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10.13'
 
-    - name: Update files after fetching data from APIs
-      run: |
-        python docs/tools/vdb_table/fetch-data.py
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests tqdm pypistats
 
-    - name: Commit and push if there are changes
-      env:
-        GIT_AUTHOR_NAME: Arunesh Singh
-        GIT_AUTHOR_EMAIL: 43724007+AruneshSingh@users.noreply.github.com
-        GIT_COMMITTER_NAME: Arunesh Singh
-        GIT_COMMITTER_EMAIL: 43724007+AruneshSingh@users.noreply.github.com
-        GITHUB_TOKEN: ${{ secrets.DATA_PUSH_TOKEN }}
-      run: |
-        git add docs/tools/vdb_table/data/.
-        git commit -m "Update Stars, Pulls & Downloads" || exit 0  # Exit 0 if no changes
-    
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.DATA_PUSH_TOKEN }}
+      - name: Fetch data from APIs
+        env:
+          PYPI_API_KEY: ${{ secrets.PYPI_API_KEY }}
+        run: python docs/tools/vdb_table/fetch-data.py
+
+      - name: Commit and push if changed
+        run: |
+          set -euo pipefail
+          git config user.name "sie-web-sync-bot[bot]"
+          git config user.email "3380232+sie-web-sync-bot[bot]@users.noreply.github.com"
+          git add docs/tools/vdb_table/data/.
+          if git diff --staged --quiet; then
+            echo "No data changes — skipping push."
+            exit 0
+          fi
+          git commit -m "Update Stars, Pulls & Downloads"
+          git push origin HEAD:main


### PR DESCRIPTION
The `DATA_PUSH_TOKEN` PAT expired and the weekly cron has been failing at `actions/checkout` with `could not read Username for 'https://github.com'`. Switching to the same GitHub App pattern used by `notify-sie-web-vdb.yml` — installation tokens are minted fresh per run, so there is no expiry to manage.