### PR TITLE
data: standardize AGPL-3.0 license labels; simplify Redis tri-license

### DIFF
--- a/docs/tools/vdb_table/data/nucliadb.json
+++ b/docs/tools/vdb_table/data/nucliadb.json
@@ -14,7 +14,7 @@
     "comment": "https://github.com/nuclia/nucliadb"
   },
   "license": {
-    "value": "AGPLv3",
+    "value": "AGPL-3.0",
     "source_url": "",
     "comment": ""
   },

--- a/docs/tools/vdb_table/data/paradedb.json
+++ b/docs/tools/vdb_table/data/paradedb.json
@@ -14,7 +14,7 @@
     "comment": ""
   },
   "license": {
-    "value": "AGPL-3.0 Licence",
+    "value": "AGPL-3.0",
     "source_url": "https://github.com/paradedb/paradedb/blob/dev/LICENSE",
     "comment": ""
   },

--- a/docs/tools/vdb_table/data/redis.json
+++ b/docs/tools/vdb_table/data/redis.json
@@ -14,7 +14,7 @@
     "comment": "Starting with Redis 8.0, both Redis and its vector search functionality are fully open source, with vector search integrated natively into Redis instead of provided as a separate RediSearch library."
   },
   "license": {
-    "value": "(i) Redis Source Available License 2.0 (RSALv2) or (ii) the Server Side Public License v1 (SSPLv1) or (iii) the GNU Affero General Public License v3 (AGPLv3)",
+    "value": "AGPL-3.0 / SSPLv1",
     "source_url": "https://redis.io/legal/licenses/",
     "comment": "Starting with Redis 8, Redis Open Source is moving to a tri-licensing model with all new Redis code contributions governed by the updated Redis Software Grant and Contributor License Agreement. After this release, contributions are subject to your choice of: (a) the Redis Source Available License v2 (RSALv2);or (b) the Server Side Public License v1 (SSPLv1); or (c) the GNU Affero General Public License v3 (AGPLv3)."
   },


### PR DESCRIPTION
Redis Search rendered as one long sentence in the comparison table on superlinked.com. Schema's `stringWithSource` doesn't accept arrays, so reducing to a `/`-delimited string of the two OSS-relevant options (mirrors how MongoDB lists `SSPLv1`).

Also aligns Nuclia DB (`AGPLv3` → `AGPL-3.0`) and ParadeDB (`AGPL-3.0 Licence` → `AGPL-3.0`) to the same label so the column groups consistently.